### PR TITLE
fix: Add bech32 to Vite optimizeDeps

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,4 +4,7 @@ import react from '@vitejs/plugin-react'
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  optimizeDeps: {
+    include: ['bech32'],
+  },
 })


### PR DESCRIPTION
Attempts to resolve an 'Uncaught SyntaxError' related to the bech32 module not providing a default export.

By adding 'bech32' to `optimizeDeps.include` in `vite.config.ts`, Vite is instructed to pre-bundle this dependency, which can help with CommonJS/ESM interoperability issues that often cause this type of error.